### PR TITLE
Made tests more verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ minverson = 1.6
 envlist = py33, py32, py27, py26
 
 [testenv]
+deps = nose
 commands =
-    python tests/tests.py
+    nosetests -v
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
tox will now use nosetests when running tests. This makes tests more verbose.

Ex:
```
t:get_address ... ok
t:bootstrap_from_address ... ok
t:get_friend_connection_status ... ok
t:file_data_remaining ... ok
t:count_friendlist ... ok
t:on_friend_action ... ok
t:add_groupchat ... ok
t:on_read_receipt ... ok
t:set_name ... ok
t:get_self_status_message ... ok
t:size ... ok
t:save_to_file ... ok
t:get_self_user_status ... ok

----------------------------------------------------------------------
Ran 13 tests in 124.248s

OK
```