### PR TITLE
Use alternative method for checking the existence of tox av

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from subprocess import Popen, PIPE
 
 
 def supports_av():
-    h = Popen("ldconfig -p | grep toxav", shell=True, stdout=PIPE)
+    h = Popen("ld -ltoxav", shell=True, stderr=PIPE)
     out, err = h.communicate()
-    return 'toxav' in str(out)
+    return 'toxav' not in str(err)
 
 sources = ["pytox/pytox.c", "pytox/core.c", "pytox/util.c"]
 libraries = ["toxcore"]


### PR DESCRIPTION
This fix is needed because on mac os there's no `ldconfig` tool. So this
alternative check is based on parsing the output of the `ld` tool. If
`ld` fails with -ltoxav not found, it means it's not there.